### PR TITLE
Add Phoenix.updateWithChannelsModelComparator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+Added `Phoenix.updateWithChannelsModelComparator`
+
 ## [1.1.3] - 2021-09-11
 Relaxed Elm version to >= 0.19.0
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ channels channelModel =
   ] ++ List.map Channel.init channelModel.rooms
 ```
 
+**Warning** - Do NOT put `Json.Encode.Value`s into your channel model.  As an optimisation, the library compares the passed channels model with the version from the previous functional call and then only calls the provided `channels` function if the model has changed.  This comparison is done with `==` and due to an issue in Elm, comparing a model with a contained `Json.Encode.Value` can cause a runtime exception. (See https://github.com/elm/core/issues/1058).
+
+If you do need to have `Json.Encode.Value`s in your channel model you can use `Phoenix.updateWithChannelsModelComparator` instead of `Phoenix.update` and provide a safe comparator for your channels model in place of the default `==`.
+
 **Warning** - If you want to leave all channels (e.g. when showing an error page to the user)
 do not remove `Phoenix.connect` from your `subscriptions` function as this will have no effect.
 Instead, return an empty list of channels from the `channels` function.


### PR DESCRIPTION
As an optimisation, the library compares the passed channels model with the version from the previous functional call and then only calls the provided `channels` function if the model has changed.  This comparison is done with `==` and due to an issue in Elm, comparing a model with a contained `Json.Encode.Value` can cause a runtime exception. (See https://github.com/elm/core/issues/1058).

To work around having `Json.Encode.Value`s in your channel model this PR adds `Phoenix.updateWithChannelsModelComparator` as a replacement for `Phoenix.update` and allows the client to provide a safe comparator for your channels model in place of the default `==`.